### PR TITLE
Using si_status is correct

### DIFF
--- a/mrbgems/mruby-signal-handler/src/mrb_signal_handler_trap.c
+++ b/mrbgems/mruby-signal-handler/src/mrb_signal_handler_trap.c
@@ -83,7 +83,7 @@ mrb_value mrb_wait_pgid(mrb_state* mrb, mrb_value self) {
         exit_status = info.si_status;
         if (info.si_code != CLD_EXITED) {
             exit_status += 128;
-            if (info.si_code == SIGINT) {
+            if (info.si_status == SIGINT) {
                 interrupt_state = 1;
             }
         }


### PR DESCRIPTION
プロセスをkillしたシグナルが入るのはsi_statusである。
see. https://linuxjm.osdn.jp/html/LDP_man-pages/man2/wait.2.html