### PR TITLE
clapのバージョンアップに伴う見直し

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -36,7 +36,6 @@ struct ReddishOptions {
 
 struct AppParameter {
     source: InputSource,
-    bin_name: String,
     positional_parameters: Vec<String>,
 }
 
@@ -63,15 +62,17 @@ impl App {
     }
 
     fn parse_args(&self, args: Vec<String>) -> Result<AppParameter, io::Error> {
-        let bin_name = args[0].to_string();
+        let my_name = args.first().unwrap().to_owned();
         let opts = ReddishOptions::parse_from(args);
+        let mut positional_parameters = opts.parameters.clone();
 
         let source = match opts.command {
             Some(command) => InputSource::Command(command.to_string()),
             None => {
-                if let Some(file) = opts.parameters.first() {
-                    InputSource::File(file.to_string())
+                if let Some(file) = positional_parameters.first() {
+                    InputSource::File(file.to_owned())
                 } else {
+                    positional_parameters.push(my_name);
                     match self.isatty() {
                         true => InputSource::Tty,
                         false => InputSource::Stdin,
@@ -80,13 +81,8 @@ impl App {
             }
         };
 
-        let positional_parameters = match opts.parameters.get(1..) {
-            Some(p) => p.to_owned(),
-            None => Vec::new(),
-        };
         Ok(AppParameter {
             source,
-            bin_name,
             positional_parameters,
         })
     }
@@ -213,7 +209,6 @@ impl App {
             {IFS, " \t\n"},
         ];
 
-        self.ctx.bin_name = params.bin_name.to_string();
         self.ctx.positional_parameters = params.positional_parameters.clone();
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -67,7 +67,7 @@ impl App {
         let mut positional_parameters = opts.parameters.clone();
 
         let source = match opts.command {
-            Some(command) => InputSource::Command(command.to_string()),
+            Some(command) => InputSource::Command(command),
             None => {
                 if let Some(file) = positional_parameters.first() {
                     InputSource::File(file.to_owned())

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 pub struct Context {
     local_vars: HashMap<String, String>,
     pub status: ExitStatus,
-    pub bin_name: String,
     pub positional_parameters: Vec<String>,
 }
 
@@ -14,7 +13,6 @@ impl Context {
         Self {
             local_vars: HashMap::new(),
             status: ExitStatus::default(),
-            bin_name: String::new(),
             positional_parameters: vec![],
         }
     }
@@ -48,7 +46,6 @@ impl Context {
     fn get_special_var<T: AsRef<str>>(&self, name: T) -> Option<String> {
         let mut c = name.as_ref().chars();
         match c.next() {
-            Some('0') => Some(self.bin_name.to_string()),
             Some(n) if n.is_ascii_digit() => {
                 let mut index = n.to_digit(10).unwrap();
                 for n in c {
@@ -59,7 +56,7 @@ impl Context {
                     index += n.to_digit(10).unwrap();
                 }
                 self.positional_parameters
-                    .get((index - 1) as usize)
+                    .get(index as usize)
                     .map(|s| s.to_string())
             }
             Some('?') => Some(self.status.code().to_string()),

--- a/src/utils/escape.rs
+++ b/src/utils/escape.rs
@@ -2,7 +2,7 @@ pub trait Escape {
     fn escape(&self) -> String;
 }
 
-impl Escape for &str {
+impl Escape for String {
     fn escape(&self) -> String {
         let mut result = String::new();
         let mut iter = self.split('\\');


### PR DESCRIPTION
clapのバージョンアップによりderiveが使えるようになった。
Builder APIを使うより直感的に扱えるので変更する。