### PR TITLE
Add debug print for lexer/parser.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -148,7 +148,7 @@ impl App {
             match rl.readline(&prompt) {
                 Ok(line) => {
                     cmdline.push_str(&line);
-                    match parse_command_line(&cmdline, linenumber) {
+                    match parse_command_line(&cmdline, linenumber, self.ctx.debug()) {
                         Ok(cmds) => {
                             if !cmds.ignore_history() && rl.add_history_entry(&cmdline) {
                                 if let Some(e) =

--- a/src/context.rs
+++ b/src/context.rs
@@ -17,6 +17,10 @@ impl Context {
         }
     }
 
+    pub fn debug(&self) -> bool {
+        matches!(self.get_var("REDDISH_DEBUG"), Some(_))
+    }
+
     pub fn set_var<T: AsRef<str>>(&mut self, name: T, value: T) -> Option<String> {
         let name = name.as_ref();
         let value = value.as_ref();

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1030,7 +1030,7 @@ impl Executor {
 
                 let mut e = Executor::new().unwrap();
                 let option = ExecOptionBuilder::new().quiet(true).pgid(pid).build();
-                let status = match parse_command_line(command, 0, true) {
+                let status = match parse_command_line(command, 0, ctx.debug()) {
                     Err(_) => ExitStatus::failure(),
                     Ok(cmds) => {
                         for cmd in cmds.to_vec() {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1030,7 +1030,7 @@ impl Executor {
 
                 let mut e = Executor::new().unwrap();
                 let option = ExecOptionBuilder::new().quiet(true).pgid(pid).build();
-                let status = match parse_command_line(command, 0) {
+                let status = match parse_command_line(command, 0, true) {
                     Err(_) => ExitStatus::failure(),
                     Ok(cmds) => {
                         for cmd in cmds.to_vec() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,13 @@ use mockable_syscall::inner as syscall;
 
 static APP_NAME: &str = "reddish";
 static VERSION: &str = crate_version!();
+
+#[macro_export]
+macro_rules! debug {
+    ($f:expr, $($arg:tt)*) => {
+        if $f {
+            eprint!("debug: ");
+            eprintln!($($arg)*);
+        }
+    };
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,7 @@ pub use command::{parse_command, ConnecterKind};
 mod command;
 mod lexer;
 
-use super::status::Result;
+use crate::{debug, status::Result};
 use lexer::Lexer;
 use redirect::RedirectList;
 use token::{Token, TokenKind, TokenReader};
@@ -103,8 +103,13 @@ pub enum UnitKind {
     },
 }
 
-pub fn parse_command_line<S: AsRef<str>>(s: S, linenumber: usize) -> Result<CommandList> {
-    let tokens = Lexer::new(s.as_ref(), linenumber).lex()?;
+pub fn parse_command_line<S: AsRef<str>>(
+    s: S,
+    linenumber: usize,
+    debug: bool,
+) -> Result<CommandList> {
+    let tokens = Lexer::new(s.as_ref(), linenumber, debug).lex()?;
+
     let mut tokens = TokenReader::new(tokens);
     let mut result = vec![];
 
@@ -119,5 +124,7 @@ pub fn parse_command_line<S: AsRef<str>>(s: S, linenumber: usize) -> Result<Comm
     }
 
     let result = CommandList::new(result, ignore_history);
+    debug!(debug, "parser result: {:?}", result);
+
     Ok(result)
 }

--- a/src/parser/command_test.rs
+++ b/src/parser/command_test.rs
@@ -16,7 +16,7 @@ mod test {
 
     macro_rules! lex {
         ($e: expr) => {
-            Lexer::new($e, 1).lex().unwrap()
+            Lexer::new($e, 1, false).lex().unwrap()
         };
     }
 

--- a/src/parser/lexer_test.rs
+++ b/src/parser/lexer_test.rs
@@ -7,7 +7,7 @@ mod test {
 
     macro_rules! assert_lex {
         ($f: ident, $s: expr, $expect: expr) => {{
-            let mut lexer = Lexer::new($s, 1);
+            let mut lexer = Lexer::new($s, 1, false);
             let got = lexer.$f().map(|t| (t, lexer.location()));
             assert_eq!($expect, got)
         }};

--- a/src/parser/redirect_test.rs
+++ b/src/parser/redirect_test.rs
@@ -9,7 +9,7 @@ mod test {
 
     macro_rules! lex {
         ($e: expr) => {
-            Lexer::new($e, 1).lex().unwrap()
+            Lexer::new($e, 1, false).lex().unwrap()
         };
     }
 


### PR DESCRIPTION
lexerとparserの実行結果を表示するオプションを追加。
`$REDDISH_DEBUG` を設定するとデバッグ表示を有効にする。

e.g.
```
❯ REDDISH_DEBUG=y cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/reddish`
reddish> date
debug: lex result: [Annotate { value: Word("date", Normal), loc: Location { column: 1, line: 1 } }]
debug: parser result: CommandList { list: [Unit { kind: SimpleCommand { command: [WordList { list: [Word { string: "date", kind: Normal, loc: Location { column: 1, line: 1 } }] }], redirect: [] }, background: false }], ignore_history: false, current: 0 }
2022年  5月 21日 土曜日 01:47:44 JST
```