### PR TITLE
Update mruby to 3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rust-mruby"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "cmd_lib",
 ]

--- a/build_config.rb.lock
+++ b/build_config.rb.lock
@@ -1,4 +1,4 @@
 ---
 mruby:
-  version: 3.0.0
-  release_no: 30000
+  version: 3.1.0
+  release_no: 30100

--- a/rust-mruby/Cargo.toml
+++ b/rust-mruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-mruby"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 
 [features]

--- a/rust-mruby/build.rs
+++ b/rust-mruby/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 #[cfg(feature = "build")]
-const DEFAULT_MRUBY_VERSION: &str = "3.0.0";
+const DEFAULT_MRUBY_VERSION: &str = "3.1.0";
 
 #[cfg(feature = "build")]
 use cmd_lib::*;


### PR DESCRIPTION
mruby 3.1がリリースされていたのでアップデートする。
https://mruby.org/releases/2022/03/12/mruby-3.1.0-released.html